### PR TITLE
Update zpl_document.py

### DIFF
--- a/simple_zpl2/zpl_document.py
+++ b/simple_zpl2/zpl_document.py
@@ -1622,6 +1622,8 @@ class QR_Barcode(_Barcode):
                              * 'M' - standard
                              * 'L' - low
     :param mask_value: 0-7 defaults 7
+    :param fd_switches: sets data-input mode between Automatic('A'), Manual('M') and character mode <N, A, Bdddd, K>.
+                        Defaults to M,A, for Manual data input, and automatic character mode. See below for documentation on Mixed Mode and Character-mode.
 
     .. note::
 
@@ -1760,13 +1762,14 @@ class QR_Barcode(_Barcode):
         n** up to 200 in mixed mode
     """
 
-    def __init__(self, data, model=None, magnification=None, error_correction=None, mask_value=None):
-        # TODO: FD data QR switches
+    def __init__(self, data, model=None, magnification=None, error_correction='M', mask_value=None, fd_switches='M,A'):
+        # FD data QR switches
+        data = '{}{}{}'.format(error_correction, fd_switches, data)
         super().__init__(data)
-        self._initial_setup(model, magnification, error_correction, mask_value)
+        self._initial_setup(model, magnification, mask_value)
         self._add_data()
 
-    def _initial_setup(self, model, magnification, error_correction, mask_value):
+    def _initial_setup(self, model, magnification, mask_value):
         self.zpl.append('^BQN')
 
         if model is None:
@@ -1777,14 +1780,9 @@ class QR_Barcode(_Barcode):
             return
         self._add_int_value_in_range(magnification, 'magnification', 1, 10, True)
 
-        if error_correction is None:
-            return
-        self._add_value_in_list(error_correction, 'error_correction', ('H', 'Q', 'M', 'L'), True)
-
         if mask_value is None:
             return
         self._add_int_value_in_range(mask_value, 'mask_value', 0, 7, True)
-
 
 class Postal_Barcode(_1DBarcode):
     """


### PR DESCRIPTION
I needed to print QR-codes, but was missing some characters at the beginning, resulting in broken QR-codes. This PR will (rather dirty, i'll admit) fix this issue and adds an extra parameter to the `QR_Barcode` constructor to override the default `MM,A` mode 

fix issue with missing characters at the beginning of a QR-code ( https://github.com/sacherjj/simple_zpl2/issues/205 )